### PR TITLE
Add PDF.js viewer template and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # VetrinaCataloghi
-Plugin WordPress per la gestione dei cataloghi
+Plugin WordPress per la gestione dei cataloghi.
+
+## Funzionalità aggiunte
+
+- Visualizzazione dei cataloghi PDF direttamente nel frontend tramite PDF.js con layout a due colonne.
+- Pagina di impostazioni per configurare il viewer PDF.js e caricare un logo personalizzato.

--- a/assets/css/pdf-viewer.css
+++ b/assets/css/pdf-viewer.css
@@ -1,0 +1,6 @@
+.vc-pdfjs-wrapper{display:flex;height:100vh;}
+.vc-pdfjs-sidebar{width:20%;padding:20px;box-sizing:border-box;overflow:auto;}
+.vc-pdfjs-viewer{width:80%;}
+.vc-pdfjs-viewer iframe{width:100%;height:100vh;border:none;}
+.vc-logo{max-width:100%;height:auto;margin-bottom:20px;}
+.vc-title{margin-top:0;}

--- a/templates/single-vetrina_catalogo.php
+++ b/templates/single-vetrina_catalogo.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Template for single catalogo posts with PDF.js viewer.
+ *
+ * @package VetrinaCataloghi
+ */
+
+get_header();
+
+$options   = get_option( 'vc_pdfjs_options', array() );
+$logo_id   = isset( $options['logo_id'] ) ? intval( $options['logo_id'] ) : 0;
+$logo_url  = $logo_id ? wp_get_attachment_image_url( $logo_id, 'full' ) : '';
+$viewer    = isset( $options['viewer_url'] ) ? $options['viewer_url'] : 'https://mozilla.github.io/pdf.js/web/viewer.html';
+$params    = isset( $options['viewer_params'] ) ? $options['viewer_params'] : '';
+$pdf_id    = get_post_meta( get_the_ID(), '_vc_pdf_id', true );
+$pdf_url   = $pdf_id ? wp_get_attachment_url( $pdf_id ) : '';
+?>
+<div class="vc-pdfjs-wrapper">
+    <div class="vc-pdfjs-sidebar">
+        <?php if ( $logo_url ) : ?>
+            <img src="<?php echo esc_url( $logo_url ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" class="vc-logo" />
+        <?php endif; ?>
+        <h1 class="vc-title"><?php the_title(); ?></h1>
+        <div class="vc-content"><?php the_content(); ?></div>
+    </div>
+    <div class="vc-pdfjs-viewer">
+        <?php if ( $pdf_url ) : ?>
+            <iframe src="<?php echo esc_url( $viewer . '?file=' . rawurlencode( $pdf_url ) . $params ); ?>"></iframe>
+        <?php else : ?>
+            <p><?php esc_html_e( 'PDF non disponibile.', 'vetrina-cataloghi' ); ?></p>
+        <?php endif; ?>
+    </div>
+</div>
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- Add PDF.js-based template with two-column layout for catalog posts
- Introduce settings page to configure viewer options and upload a logo
- Include CSS and frontend hooks for responsive viewer

## Testing
- `php -l vetrina-cataloghi.php templates/single-vetrina_catalogo.php`


------
https://chatgpt.com/codex/tasks/task_e_68c67d83d76c8332838a18d4f77a44d3