### PR TITLE
Use bundled PDF.js viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Plugin WordPress per la gestione dei cataloghi.
 ## Funzionalità aggiunte
 
 - Visualizzazione dei cataloghi PDF direttamente nel frontend tramite PDF.js con layout a due colonne.
-- Pagina di impostazioni per configurare il viewer PDF.js e caricare un logo personalizzato.
+- Pagina di impostazioni per configurare i parametri del viewer PDF.js e caricare un logo personalizzato.

--- a/templates/single-vetrina_catalogo.php
+++ b/templates/single-vetrina_catalogo.php
@@ -10,7 +10,7 @@ $logo_id   = isset( $options['logo_id'] ) ? intval( $options['logo_id'] ) : 0;
 $logo_url  = $logo_id ? wp_get_attachment_image_url( $logo_id, 'full' ) : '';
 $params    = isset( $options['viewer_params'] ) ? $options['viewer_params'] : '';
 // Use the bundled PDF.js viewer directly from the plugin.
-$viewer    = plugin_dir_url( dirname( __DIR__ ) ) . 'pdfjs-5-4-149/web/viewer.html';
+$viewer    = plugins_url( 'pdfjs-5-4-149/web/viewer.html', dirname( __FILE__, 2 ) );
 $pdf_id    = get_post_meta( get_the_ID(), '_vc_pdf_id', true );
 $pdf_url   = $pdf_id ? wp_get_attachment_url( $pdf_id ) : '';
 

--- a/vetrina-cataloghi.php
+++ b/vetrina-cataloghi.php
@@ -284,7 +284,6 @@ add_action( 'admin_init', 'vc_register_settings' );
  */
 function vc_sanitize_options( $input ) {
     $output = array();
-    $output['viewer_url']    = isset( $input['viewer_url'] ) ? esc_url_raw( $input['viewer_url'] ) : '';
     $output['viewer_params'] = isset( $input['viewer_params'] ) ? sanitize_text_field( $input['viewer_params'] ) : '';
     $output['logo_id']       = isset( $input['logo_id'] ) ? intval( $input['logo_id'] ) : 0;
     return $output;
@@ -312,7 +311,6 @@ function vc_render_settings_page() {
     $options   = get_option( 'vc_pdfjs_options', array() );
     $logo_id   = isset( $options['logo_id'] ) ? intval( $options['logo_id'] ) : 0;
     $logo_url  = $logo_id ? wp_get_attachment_url( $logo_id ) : '';
-    $viewer_url = isset( $options['viewer_url'] ) ? esc_url( $options['viewer_url'] ) : '';
     $params     = isset( $options['viewer_params'] ) ? esc_attr( $options['viewer_params'] ) : '';
     ?>
     <div class="wrap">
@@ -320,10 +318,6 @@ function vc_render_settings_page() {
         <form method="post" action="options.php">
             <?php settings_fields( 'vc_pdfjs_settings' ); ?>
             <table class="form-table" role="presentation">
-                <tr>
-                    <th scope="row"><label for="vc-viewer-url"><?php esc_html_e( 'URL viewer PDF.js', 'vetrina-cataloghi' ); ?></label></th>
-                    <td><input type="text" id="vc-viewer-url" name="vc_pdfjs_options[viewer_url]" value="<?php echo esc_attr( $viewer_url ); ?>" class="regular-text" /></td>
-                </tr>
                 <tr>
                     <th scope="row"><label for="vc-viewer-params"><?php esc_html_e( 'Parametri viewer', 'vetrina-cataloghi' ); ?></label></th>
                     <td><input type="text" id="vc-viewer-params" name="vc_pdfjs_options[viewer_params]" value="<?php echo $params; ?>" class="regular-text" />


### PR DESCRIPTION
## Summary
- Drop PDF.js viewer URL option and sanitize only viewer parameters and logo
- Use bundled PDF.js viewer in the template via plugins_url
- Update documentation to reflect built-in viewer configuration

## Testing
- `php -l vetrina-cataloghi.php && php -l templates/single-vetrina_catalogo.php`

------
https://chatgpt.com/codex/tasks/task_e_68c694fd10fc833281112bb58c42e70c