### PR TITLE
Add CSS customization and enforce PDF.js feature settings

### DIFF
--- a/pdfjs-5-4-149/web/viewer.html
+++ b/pdfjs-5-4-149/web/viewer.html
@@ -783,5 +783,46 @@ See https://github.com/adobe-type-tools/cmap-resources
 
     </div> <!-- outerContainer -->
     <div id="printContainer"></div>
+    <script>
+      (function() {
+        const params = new URLSearchParams(window.location.hash.substring(1));
+        const hide = id => {
+          const el = document.getElementById(id);
+          if (el) {
+            el.style.display = 'none';
+          }
+        };
+        if (params.get('toolbar') === '0') {
+          const toolbar = document.querySelector('.toolbar');
+          if (toolbar) {
+            toolbar.style.display = 'none';
+          }
+        }
+        if (params.get('navpanes') === '0') {
+          hide('sidebarContainer');
+          hide('toolbarSidebar');
+          hide('sidebarToggleButton');
+        }
+        if (params.get('download') === '0') {
+          hide('downloadButton');
+          hide('secondaryDownload');
+        }
+        if (params.get('print') === '0') {
+          hide('printButton');
+          hide('secondaryPrint');
+        }
+        if (params.get('openfile') === '0') {
+          hide('secondaryOpenFile');
+        }
+        if (params.get('viewBookmark') === '0') {
+          hide('viewBookmark');
+          hide('viewBookmarkSeparator');
+        }
+        if (params.get('secondaryToolbar') === '0') {
+          hide('secondaryToolbarToggle');
+          hide('secondaryToolbar');
+        }
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Disable PDF.js viewer controls based on plugin settings
- Allow custom template styling through a CodeMirror-powered CSS editor

## Testing
- `php -l vetrina-cataloghi.php`
- `npx --yes htmlhint pdfjs-5-4-149/web/viewer.html` *(fails: attribute double-quote and tag issues in pdf.js template)*

------
https://chatgpt.com/codex/tasks/task_e_68c69ef8051c8332b88ce2da5e8b8a8b