### PR TITLE
Add catalog taxonomy archive template with pagination

### DIFF
--- a/templates/taxonomy-categoria_cataloghi.php
+++ b/templates/taxonomy-categoria_cataloghi.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Template for catalog category listings.
+ *
+ * @package VetrinaCataloghi
+ */
+
+get_header();
+?>
+
+<style>
+.vc-cataloghi-grid{display:flex;flex-wrap:wrap;margin:0 -10px;}
+.vc-cataloghi-item{width:25%;padding:0 10px;box-sizing:border-box;margin-bottom:20px;text-align:center;}
+@media(max-width:1024px){.vc-cataloghi-item{width:33.3333%;}}
+@media(max-width:768px){.vc-cataloghi-item{width:50%;}}
+@media(max-width:480px){.vc-cataloghi-item{width:100%;}}
+.vc-cataloghi-item h3{font-size:1.1em;margin-top:10px;}
+</style>
+
+<div class="vc-cataloghi-grid">
+<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+    <div class="vc-cataloghi-item">
+        <a href="<?php the_permalink(); ?>" target="_blank" rel="noopener">
+            <?php if ( has_post_thumbnail() ) { the_post_thumbnail( 'medium' ); } ?>
+        </a>
+        <h3><a href="<?php the_permalink(); ?>" target="_blank" rel="noopener"><?php the_title(); ?></a></h3>
+    </div>
+<?php endwhile; ?>
+</div>
+
+<?php
+the_posts_pagination( array(
+    'mid_size'  => 2,
+    'prev_text' => __( '&laquo; Precedente', 'vetrina-cataloghi' ),
+    'next_text' => __( 'Successivo &raquo;', 'vetrina-cataloghi' ),
+) );
+else :
+    echo '<p>' . esc_html__( 'Nessun catalogo trovato.', 'vetrina-cataloghi' ) . '</p>';
+endif;
+?>
+
+<?php get_footer(); ?>

--- a/vetrina-cataloghi.php
+++ b/vetrina-cataloghi.php
@@ -282,6 +282,37 @@ function vc_single_template( $template ) {
 add_filter( 'single_template', 'vc_single_template' );
 
 /**
+ * Load custom template for catalog categories taxonomy.
+ *
+ * @param string $template Current template.
+ * @return string Template path.
+ */
+function vc_taxonomy_template( $template ) {
+    if ( is_tax( 'categoria_cataloghi' ) ) {
+        $custom = plugin_dir_path( __FILE__ ) . 'templates/taxonomy-categoria_cataloghi.php';
+        if ( file_exists( $custom ) ) {
+            return $custom;
+        }
+    }
+    return $template;
+}
+add_filter( 'taxonomy_template', 'vc_taxonomy_template' );
+
+/**
+ * Set posts per page for catalog archives and taxonomy listings.
+ *
+ * @param WP_Query $query The WP_Query instance.
+ */
+function vc_cataloghi_posts_per_page( $query ) {
+    if ( ! is_admin() && $query->is_main_query() ) {
+        if ( $query->is_post_type_archive( 'vetrina_catalogo' ) || $query->is_tax( 'categoria_cataloghi' ) ) {
+            $query->set( 'posts_per_page', 20 );
+        }
+    }
+}
+add_action( 'pre_get_posts', 'vc_cataloghi_posts_per_page' );
+
+/**
  * Register settings for PDF.js viewer.
  */
 function vc_register_settings() {


### PR DESCRIPTION
## Summary
- add taxonomy template for `categoria_cataloghi` displaying catalog grid
- set posts per page to 20 and load custom taxonomy template from plugin

## Testing
- `php -l vetrina-cataloghi.php`
- `php -l templates/taxonomy-categoria_cataloghi.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6b19a215483329af9d26c66703af0