### PR TITLE
Add catalog list shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,19 @@ Plugin WordPress per la gestione dei cataloghi.
 
 - Visualizzazione dei cataloghi PDF direttamente nel frontend tramite PDF.js con layout a due colonne.
 - Pagina di impostazioni per configurare i parametri del viewer PDF.js e caricare un logo personalizzato.
+
+## Shortcode Cataloghi
+
+Lo shortcode `[vc_cataloghi]` consente di mostrare un elenco di cataloghi in modo responsive.
+
+Attributi disponibili:
+
+- `categoria`: slug della categoria da filtrare (facoltativo).
+- `numero`: numero di cataloghi da mostrare, oppure `tutti` per visualizzarli tutti.
+- `per_riga`: numero di cataloghi per riga sui dispositivi larghi (default 3).
+
+Esempio:
+
+```
+[vc_cataloghi categoria="promo" numero="6" per_riga="3"]
+```

--- a/assets/css/cataloghi-shortcode.css
+++ b/assets/css/cataloghi-shortcode.css
@@ -1,0 +1,22 @@
+.vc-cataloghi-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: 1fr;
+}
+@media (min-width: 600px) {
+    .vc-cataloghi-grid {
+        grid-template-columns: repeat(var(--vc-columns, 3), 1fr);
+    }
+}
+.vc-cataloghi-item img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+.vc-cataloghi-item h3 {
+    font-size: 1.1em;
+    margin-top: 0.5em;
+}
+.vc-cataloghi-item a {
+    text-decoration: none;
+}


### PR DESCRIPTION
## Summary
- add `[vc_cataloghi]` shortcode for catalog lists with category filtering, item count and per-row control
- style catalog lists with responsive CSS grid
- document new shortcode usage in README

## Testing
- `php -l vetrina-cataloghi.php`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b5ae02088332b36db79cdeb97e80