### PR TITLE
Add mobile media query for PDF iframe height

### DIFF
--- a/assets/css/pdf-viewer.css
+++ b/assets/css/pdf-viewer.css
@@ -5,6 +5,9 @@
 .vc-logo{max-width:100%;height:auto;margin-bottom:20px;}
 .vc-title{margin-top:0;}
 body{margin:0;}
+@media(max-width:767px){
+    .vc-pdfjs-viewer iframe{height:60vh;}
+}
 @media(min-width:768px){
     .vc-pdfjs-wrapper{flex-direction:row;}
     .vc-pdfjs-viewer{width:80%;}


### PR DESCRIPTION
## Summary
- ensure PDF iframe height on small screens is 60vh for scroll accessibility

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `php -l vetrina-cataloghi.php`


------
https://chatgpt.com/codex/tasks/task_e_68c6c0b036d0833284da20f533256742