### PR TITLE
Add customizable info text for catalog viewer

### DIFF
--- a/assets/css/pdf-viewer.css
+++ b/assets/css/pdf-viewer.css
@@ -4,6 +4,8 @@
 .vc-pdfjs-viewer iframe{width:100%;height:100vh;border:none;}
 .vc-logo{max-width:100%;height:auto;margin-bottom:20px;}
 .vc-title{margin-top:0;}
+.vc-info-text{margin:20px 0;font-size:0.95em;line-height:1.5;}
+.vc-info-text p:last-child{margin-bottom:0;}
 body{margin:0;}
 @media(max-width:767px){
     .vc-pdfjs-viewer iframe{height:60vh;}

--- a/templates/single-vetrina_catalogo.php
+++ b/templates/single-vetrina_catalogo.php
@@ -9,6 +9,7 @@ $options   = get_option( 'vc_pdfjs_options', array() );
 $logo_id   = isset( $options['logo_id'] ) ? intval( $options['logo_id'] ) : 0;
 $logo_url  = $logo_id ? wp_get_attachment_image_url( $logo_id, 'full' ) : '';
 $features  = isset( $options['features'] ) ? $options['features'] : array();
+$info_text_option = isset( $options['info_text'] ) ? $options['info_text'] : '';
 // Build PDF.js parameters from selected features.
 $available_features = array( 'toolbar', 'navpanes', 'download', 'print', 'openfile', 'viewBookmark', 'secondaryToolbar' );
 $params = '#zoom=page-width';
@@ -20,6 +21,8 @@ foreach ( $available_features as $feature ) {
 $viewer    = plugins_url( 'pdfjs-5-4-149/web/viewer.html', plugin_dir_path( __DIR__ ) . 'vetrina-cataloghi.php' );
 $pdf_id    = get_post_meta( get_the_ID(), '_vc_pdf_id', true );
 $pdf_url   = $pdf_id ? wp_get_attachment_url( $pdf_id ) : '';
+$info_text_meta = get_post_meta( get_the_ID(), '_vc_info_text', true );
+$info_text      = '' !== trim( (string) $info_text_meta ) ? $info_text_meta : $info_text_option;
 
 // Force the PDF URL to use the current site's domain.
 if ( $pdf_url ) {
@@ -53,6 +56,9 @@ if ( $pdf_url ) {
                 <img src="<?php echo esc_url( $logo_url ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name' ) ); ?>" class="vc-logo" />
             <?php endif; ?>
             <h1 class="vc-title"><?php the_title(); ?></h1>
+            <?php if ( ! empty( $info_text ) ) : ?>
+                <div class="vc-info-text"><?php echo wp_kses_post( wpautop( $info_text ) ); ?></div>
+            <?php endif; ?>
             <div class="vc-content"><?php the_content(); ?></div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a catalog meta box with a text area to override the global informative text
- extend the PDF.js settings with a configurable "Testo informativo" option and persist it safely
- render the informative text in the single catalog sidebar and style it for readability

## Testing
- php -l vetrina-cataloghi.php
- php -l templates/single-vetrina_catalogo.php

------
https://chatgpt.com/codex/tasks/task_e_68ca9fdd95d48332ac4f9f0f60319e59