### PR TITLE
Enable shortcode rendering in info text areas

### DIFF
--- a/templates/single-vetrina_catalogo.php
+++ b/templates/single-vetrina_catalogo.php
@@ -57,7 +57,7 @@ if ( $pdf_url ) {
             <?php endif; ?>
             <h1 class="vc-title"><?php the_title(); ?></h1>
             <?php if ( ! empty( $info_text ) ) : ?>
-                <div class="vc-info-text"><?php echo wp_kses_post( wpautop( $info_text ) ); ?></div>
+                <div class="vc-info-text"><?php echo apply_filters( 'the_content', $info_text ); ?></div>
             <?php endif; ?>
             <div class="vc-content"><?php the_content(); ?></div>
         </div>


### PR DESCRIPTION
## Summary
- render catalog info text through the standard content filter so any embedded shortcodes in the global or per-catalog text areas are executed

## Testing
- php -l templates/single-vetrina_catalogo.php

------
https://chatgpt.com/codex/tasks/task_e_68caa245c0d083329a0e7c7bfad53d45